### PR TITLE
Request header needs to be Content-Type, not Accept

### DIFF
--- a/virustotal3/core.py
+++ b/virustotal3/core.py
@@ -36,7 +36,7 @@ def get_analysis(api_key, analysis_id, proxies=None, timeout=None):
     try:
         response = requests.get('https://www.virustotal.com/api/v3/analyses/{}'.format(analysis_id),
                                 headers={'x-apikey': api_key,
-                                         'Accept': 'application/json'},
+                                         'Content-Type': 'application/json'},
                                 proxies=proxies,
                                 timeout=timeout)
         if response.status_code != 200:
@@ -63,7 +63,7 @@ class Files:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/files'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
         if api_key is None:
@@ -418,7 +418,7 @@ class URL:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/urls'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
         if api_key is None:
@@ -625,7 +625,7 @@ class Domains:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/domains'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
         if api_key is None:
@@ -775,7 +775,7 @@ class IP:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/ip_addresses'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
         if api_key is None:

--- a/virustotal3/enterprise.py
+++ b/virustotal3/enterprise.py
@@ -54,7 +54,7 @@ def search(api_key, query, order=None, limit=None, cursor=None,
         response = requests.get('https://www.virustotal.com/api/v3/intelligence/search',
                                 params=params,
                                 headers={'x-apikey': api_key,
-                                         'Accept': 'application/json'},
+                                         'Content-Type': 'application/json'},
                                 proxies=proxies,
                                 timeout=timeout)
 
@@ -86,7 +86,7 @@ def _get_feed(api_key, type_, time, timeout=None):
     try:
         response = requests.get('https://www.virustotal.com/api/v3/feeds/{}/{}'.format(type_, time),
                                 headers={'x-apikey': api_key,
-                                         'Accept': 'application/json'},
+                                         'Content-Type': 'application/json'},
                                 timeout=timeout)
 
         if response.status_code != 200:
@@ -157,7 +157,7 @@ class Livehunt:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/intelligence'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
         if api_key is None:
@@ -424,7 +424,7 @@ class Retrohunt:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/intelligence'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
     def get_jobs(self, job_id=None, limit=None, fltr=None, cursor=None, timeout=None):
@@ -584,7 +584,7 @@ class Accounts:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
     def info_user(self, user_id, timeout=None):
@@ -691,7 +691,7 @@ class ZipFiles:
         self.api_key = api_key
         self.base_url = 'https://www.virustotal.com/api/v3/intelligence'
         self.headers = {'x-apikey': self.api_key,
-                        'Accept': 'application/json'}
+                        'Content-Type': 'application/json'}
         self.proxies = proxies
 
     def create_zip(self, data, timeout=None):


### PR DESCRIPTION
I was getting errors from VT that the Content-Type header needed to be set rather than Accept. Upon changing these, several of the tests in the examples directory started working again. Can you confirm, and merge if this helps?